### PR TITLE
Drop dependency on thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ futures-core = { version = "0.3", optional = true, default-features = false, fea
 futures-util = { version = "0.3", optional = true, default-features = false, features = ["std", "sink"] }
 pin-project-lite = { version = "0.2", default-features = false }
 tar = { version = "0.4", default-features = false }
-thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/src/read/error.rs
+++ b/src/read/error.rs
@@ -1,9 +1,9 @@
+use std::fmt;
 use std::io::{Error as IoError, ErrorKind, Result};
 use std::task::Poll;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum ReadError {
-    #[error("expecting more data for entry; expected = {expected}, received = {received}")]
     UnexpectedEof { expected: usize, received: usize },
 }
 
@@ -12,6 +12,19 @@ impl ReadError {
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::UnexpectedEof { .. } => ErrorKind::UnexpectedEof,
+        }
+    }
+}
+
+impl std::error::Error for ReadError {}
+
+impl fmt::Display for ReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedEof { expected, received } => format!(
+                "expecting more data for entry; expected = {expected}, received = {received}"
+            )
+            .fmt(f),
         }
     }
 }

--- a/src/shared/state.rs
+++ b/src/shared/state.rs
@@ -1,18 +1,14 @@
+use std::fmt;
 use std::io::{Error as IoError, ErrorKind, Result};
 
 use crate::TRACING_ENABLED;
 
 use super::block::{BLOCK_SIZE, Header};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum Error {
-    #[error("expecting header")]
     ExpectingHeader,
-
-    #[error("expecting empty block")]
     ExpectingEmptyBlock,
-
-    #[error("cannot process data after eof")]
     Eof,
 }
 
@@ -20,6 +16,18 @@ impl Error {
     #[inline]
     pub fn kind(&self) -> ErrorKind {
         ErrorKind::InvalidData
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExpectingHeader => "expecting header".fmt(f),
+            Self::ExpectingEmptyBlock => "expecting empty block".fmt(f),
+            Self::Eof => "cannot process data after eof".fmt(f),
+        }
     }
 }
 

--- a/src/write/error.rs
+++ b/src/write/error.rs
@@ -1,15 +1,11 @@
+use std::fmt;
 use std::io::{Error as IoError, ErrorKind, Result};
 use std::task::Poll;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum WriteError {
-    #[error("expecting more data for entry; expected = {expected}, received = {received}")]
     UnexpectedEof { expected: u64, received: u64 },
-
-    #[error("failed to write the buffered data")]
     WriteZero,
-
-    #[error("cannot write new entry while another is being written")]
     OverlappingEntry,
 }
 
@@ -20,6 +16,23 @@ impl WriteError {
             Self::UnexpectedEof { .. } => ErrorKind::UnexpectedEof,
             Self::WriteZero => ErrorKind::WriteZero,
             Self::OverlappingEntry => ErrorKind::Unsupported,
+        }
+    }
+}
+
+impl std::error::Error for WriteError {}
+
+impl fmt::Display for WriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedEof { expected, received } => format!(
+                "expecting more data for entry; expected = {expected}, received = {received}"
+            )
+            .fmt(f),
+            Self::WriteZero => "failed to write the buffered data".fmt(f),
+            Self::OverlappingEntry => {
+                "cannot write new entry while another is being written".fmt(f)
+            }
         }
     }
 }


### PR DESCRIPTION
It brings proc-macro with it and we only use thiserror in a couple of places so it’s not worth the additional burden.